### PR TITLE
removed immutablejs for handling state immutability

### DIFF
--- a/generators/container/reducer.js.hbs
+++ b/generators/container/reducer.js.hbs
@@ -17,7 +17,7 @@ export const {{ camelCase name }}Reducer = (state = initialState, action) =>
   produce(state, (/* draft */) => {
     switch (action.type) {
       case {{ camelCase name}}Types.DEFAULT_ACTION:
-        return {...state, somePayload: action.payload}
+        return {...state, somePayload: action.somePayload}
       default:
         return state
     }

--- a/generators/container/reducer.js.hbs
+++ b/generators/container/reducer.js.hbs
@@ -17,7 +17,7 @@ export const {{ camelCase name }}Reducer = (state = initialState, action) =>
   produce(state, (/* draft */) => {
     switch (action.type) {
       case {{ camelCase name}}Types.DEFAULT_ACTION:
-        return {...state, action.payload}
+        return {...state, somePayload: action.payload}
       default:
         return state
     }

--- a/generators/container/reducer.js.hbs
+++ b/generators/container/reducer.js.hbs
@@ -4,10 +4,9 @@
  *
  */
 import produce from 'immer'
-import { fromJS } from 'immutable'
 import { createActions } from 'reduxsauce'
 
-export const initialState = fromJS({})
+export const initialState = {}
 
 export const { Types: {{ camelCase name }}Types, Creators: {{ camelCase name }}Creators } = createActions({
   defaultAction: ['somePayload']
@@ -18,7 +17,7 @@ export const {{ camelCase name }}Reducer = (state = initialState, action) =>
   produce(state, (/* draft */) => {
     switch (action.type) {
       case {{ camelCase name}}Types.DEFAULT_ACTION:
-        return state.set('somePayload', action.somePayload)
+        return {...state, action.payload}
       default:
         return state
     }

--- a/generators/container/reducer.test.js.hbs
+++ b/generators/container/reducer.test.js.hbs
@@ -1,5 +1,4 @@
 // import produce from 'immer'
-import { fromJS } from 'immutable';
 import { {{ camelCase name }}Reducer, {{ camelCase name }}Types, initialState } from '../reducer'
 
 /* eslint-disable default-case, no-param-reassign */
@@ -14,7 +13,7 @@ describe('{{ properCase name }} reducer tests', () => {
   })
 
   it('should return the update the state when an action of type DEFAULT is dispatched', () => {
-    const expectedResult = fromJS(state.toJS()).set('somePayload', 'Mohammed Ali Chherawalla')
+    const expectedResult = {...state, somePayload: 'Mohammed Ali Chherawalla'}
     expect(
       {{ camelCase name }}Reducer(state, {
         type: {{ camelCase name}}Types.DEFAULT_ACTION,

--- a/generators/container/selectors.js.hbs
+++ b/generators/container/selectors.js.hbs
@@ -5,7 +5,7 @@ import { initialState } from './reducer'
  * Direct selector to the {{ camelCase name }} state domain
  */
 
-const select{{ properCase name }}Domain = state => (state.{{ camelCase name }} || initialState)
+const select{{ properCase name }}Domain = state => state.{{ camelCase name }} || initialState
 
 const makeSelect{{ properCase name }} = () =>
   createSelector(select{{ properCase name }}Domain, substate => substate)

--- a/generators/container/selectors.js.hbs
+++ b/generators/container/selectors.js.hbs
@@ -5,7 +5,7 @@ import { initialState } from './reducer'
  * Direct selector to the {{ camelCase name }} state domain
  */
 
-const select{{ properCase name }}Domain = state => (state.{{ camelCase name }} || initialState).toJS()
+const select{{ properCase name }}Domain = state => (state.{{ camelCase name }} || initialState)
 
 const makeSelect{{ properCase name }} = () =>
   createSelector(select{{ properCase name }}Domain, substate => substate)

--- a/generators/container/selectors.test.js.hbs
+++ b/generators/container/selectors.test.js.hbs
@@ -1,4 +1,3 @@
-import { fromJS } from 'immutable'
 import { select{{ properCase name }}Domain } from '../selectors'
 
 describe('{{ properCase name }} selector tests', () => {
@@ -6,11 +5,11 @@ describe('{{ properCase name }} selector tests', () => {
 
   beforeEach(() => {
     mockedState = {
-      {{ camelCase name }}: fromJS({})
+      {{ camelCase name }}: {}
     }
   })
 
   it('should select the user state', () => {
-    expect(select{{ properCase name }}Domain(mockedState)).toEqual(mockedState.{{ camelCase name }}.toJS())
+    expect(select{{ properCase name }}Domain(mockedState)).toEqual(mockedState.{{ camelCase name }}
   })
 })

--- a/generators/container/selectors.test.js.hbs
+++ b/generators/container/selectors.test.js.hbs
@@ -10,6 +10,6 @@ describe('{{ properCase name }} selector tests', () => {
   })
 
   it('should select the user state', () => {
-    expect(select{{ properCase name }}Domain(mockedState)).toEqual(mockedState.{{ camelCase name }}
+    expect(select{{ properCase name }}Domain(mockedState)).toEqual(mockedState.{{ camelCase name }})
   })
 })


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
---------------------------------------------------
- Removed immutable js as we are using immer for handling immutability.
- no need to use fromJs() and toJs() for selecting and creating state.
- updated tests for respective files

### Steps to Reproduce / Test
---------------------------------------------------


### GIF's
---------------------------------------------------
